### PR TITLE
ci: update release-please action from v4 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     
     steps:
       - name: Create Release PR or Publish Release
-        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v4@main
+        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         id: release
         with:
           release-type: node


### PR DESCRIPTION
Updates the googleapis/release-please-action reference in the CI workflow from v4 to v5.